### PR TITLE
fix: allow enable `ahash` and `strsim` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ repository = "https://github.com/leontoeides/indicium"
 rust-version = "1.73.0"
 
 [features]
-default = ["simple"]
+default = ["simple", "rustc-hash", "rapidfuzz"]
 
-simple = ["rapidfuzz", "rustc-hash"]
+simple = []
 select2 = ["simple", "dep:serde"]
 
 fuzzy = ["rapidfuzz"]


### PR DESCRIPTION
Fix "features `ahash` and `rustc-hash` cannot both be enabled" error if enable `ahash` feature